### PR TITLE
Add missing variables and functions to documentation

### DIFF
--- a/.meta/template/globals.lua
+++ b/.meta/template/globals.lua
@@ -235,7 +235,7 @@ function physics.lineIntersectVehicleQuick(vehicle, posA, posB) end
 ---@param posA Vector The start point of the ray.
 ---@param posB Vector The end point of the ray.
 ---@param ignoreHuman? Human The human to ignore during raycast.
----@return object? Object The nearest human or vehicle that the ray hit.
+---@return object? Human|Vehicle The nearest human or vehicle that the ray hit.
 function physics.lineIntersectAnyQuick(posA, posB, ignoreHuman) end
 
 ---Cast a ray on an arbitrary triangle.

--- a/.meta/template/globals.lua
+++ b/.meta/template/globals.lua
@@ -211,6 +211,37 @@ function physics.lineIntersectHuman(human, posA, posB) end
 ---@return LineIntersectResult result The result of the intersection.
 function physics.lineIntersectVehicle(vehicle, posA, posB) end
 
+---Cast a quick ray in the level and find how far along the ray it went.
+---@param posA Vector The start point of the ray.
+---@param posB Vector The end point of the ray.
+---@param state?
+---@return number? fraction The fraction of the intersection.
+function physics.lineIntersectLevelQuick(posA, posB, state) end
+
+---Cast a quick ray on a single human.
+---@param human Human The human to cast the ray on.
+---@param posA Vector The start point of the ray.
+---@param posB Vector The end point of the ray.
+---@param state?
+---@return number? fraction The fraction of the intersection.
+function physics.lineIntersectHumanQuick(human, posA, posB, state) end
+
+---Cast a quick ray on a single vehicle.
+---@param vehicle Vehicle The vehicle to cast the ray on.
+---@param posA Vector The start point of the ray.
+---@param posB Vector The end point of the ray.
+---@param state?
+---@return number? fraction The fraction of the intersection.
+function physics.lineIntersectVehicleQuick(vehicle, posA, posB, state) end
+
+---Cast a quick ray on any human or vehicle.
+---@param posA Vector The start point of the ray.
+---@param posB Vector The end point of the ray.
+---@param ignoreHuman? Human The human to ignore during raycast.
+---@param state?
+---@return object? Object The nearest human or vehicle that the ray hit.
+function physics.lineIntersectAnyQuick(posA, posB, ignoreHuman, state) end
+
 ---Cast a ray on an arbitrary triangle.
 ---The vertices of the triangle must be clockwise relative to the normal.
 ---The vector passed to outPosition will be modified by the function.
@@ -223,33 +254,6 @@ function physics.lineIntersectVehicle(vehicle, posA, posB) end
 ---@param triC Vector The third vertex of the triangle.
 ---@return number? fraction How far along the ray hit was (0.0 - 1.0). Nil if it did not hit.
 function physics.lineIntersectTriangle(outPosition, normal, posA, posB, triA, triB, triC) end
-
----Cast a quick ray in the level and find how far along the ray it went.
----@param posA Vector The start point of the ray.
----@param posB Vector The end point of the ray.
----@return number? fraction The fraction of the intersection.
-function physics.lineIntersectLevelQuick(posA, posB) end
-
----Cast a quick ray on a single human.
----@param human Human The human to cast the ray on.
----@param posA Vector The start point of the ray.
----@param posB Vector The end point of the ray.
----@return number? fraction The fraction of the intersection.
-function physics.lineIntersectHumanQuick(human, posA, posB) end
-
----Cast a quick ray on a single vehicle.
----@param vehicle Vehicle The vehicle to cast the ray on.
----@param posA Vector The start point of the ray.
----@param posB Vector The end point of the ray.
----@return number? fraction The fraction of the intersection.
-function physics.lineIntersectVehicleQuick(vehicle, posA, posB) end
-
----Cast a quick ray on any human or vehicle.
----@param posA Vector The start point of the ray.
----@param posB Vector The end point of the ray.
----@param ignoreHuman? Human The human to ignore during raycast.
----@return object? Object The nearest human or vehicle that the ray hit.
-function physics.lineIntersectAnyQuick(posA, posB, ignoreHuman) end
 
 ---Remove all bullets that have no time remaining.
 ---May shift bullets in memory if any are removed.

--- a/.meta/template/globals.lua
+++ b/.meta/template/globals.lua
@@ -224,6 +224,33 @@ function physics.lineIntersectVehicle(vehicle, posA, posB) end
 ---@return number? fraction How far along the ray hit was (0.0 - 1.0). Nil if it did not hit.
 function physics.lineIntersectTriangle(outPosition, normal, posA, posB, triA, triB, triC) end
 
+---Cast a quick ray in the level and find how far along the ray it went.
+---@param posA Vector The start point of the ray.
+---@param posB Vector The end point of the ray.
+---@return number? fraction The fraction of the intersection.
+function physics.lineIntersectLevelQuick(posA, posB) end
+
+---Cast a quick ray on a single human.
+---@param human Human The human to cast the ray on.
+---@param posA Vector The start point of the ray.
+---@param posB Vector The end point of the ray.
+---@return number? fraction The fraction of the intersection.
+function physics.lineIntersectHumanQuick(human, posA, posB) end
+
+---Cast a quick ray on a single vehicle.
+---@param vehicle Vehicle The vehicle to cast the ray on.
+---@param posA Vector The start point of the ray.
+---@param posB Vector The end point of the ray.
+---@return number? fraction The fraction of the intersection.
+function physics.lineIntersectVehicleQuick(vehicle, posA, posB) end
+
+---Cast a quick ray on any human or vehicle.
+---@param posA Vector The start point of the ray.
+---@param posB Vector The end point of the ray.
+---@param ignoreHuman? Human The human to ignore during raycast.
+---@return object? Object The nearest human or vehicle that the ray hit.
+function physics.lineIntersectAnyQuick(posA, posB, ignoreHuman) end
+
 ---Remove all bullets that have no time remaining.
 ---May shift bullets in memory if any are removed.
 function physics.garbageCollectBullets() end

--- a/.meta/template/globals.lua
+++ b/.meta/template/globals.lua
@@ -214,33 +214,29 @@ function physics.lineIntersectVehicle(vehicle, posA, posB) end
 ---Cast a quick ray in the level and find how far along the ray it went.
 ---@param posA Vector The start point of the ray.
 ---@param posB Vector The end point of the ray.
----@param state?
 ---@return number? fraction The fraction of the intersection.
-function physics.lineIntersectLevelQuick(posA, posB, state) end
+function physics.lineIntersectLevelQuick(posA, posB) end
 
 ---Cast a quick ray on a single human.
 ---@param human Human The human to cast the ray on.
 ---@param posA Vector The start point of the ray.
 ---@param posB Vector The end point of the ray.
----@param state?
 ---@return number? fraction The fraction of the intersection.
-function physics.lineIntersectHumanQuick(human, posA, posB, state) end
+function physics.lineIntersectHumanQuick(human, posA, posB) end
 
 ---Cast a quick ray on a single vehicle.
 ---@param vehicle Vehicle The vehicle to cast the ray on.
 ---@param posA Vector The start point of the ray.
 ---@param posB Vector The end point of the ray.
----@param state?
 ---@return number? fraction The fraction of the intersection.
-function physics.lineIntersectVehicleQuick(vehicle, posA, posB, state) end
+function physics.lineIntersectVehicleQuick(vehicle, posA, posB) end
 
 ---Cast a quick ray on any human or vehicle.
 ---@param posA Vector The start point of the ray.
 ---@param posB Vector The end point of the ray.
 ---@param ignoreHuman? Human The human to ignore during raycast.
----@param state?
 ---@return object? Object The nearest human or vehicle that the ray hit.
-function physics.lineIntersectAnyQuick(posA, posB, ignoreHuman, state) end
+function physics.lineIntersectAnyQuick(posA, posB, ignoreHuman) end
 
 ---Cast a ray on an arbitrary triangle.
 ---The vertices of the triangle must be clockwise relative to the normal.

--- a/.meta/template/types.lua
+++ b/.meta/template/types.lua
@@ -204,7 +204,7 @@ do
 	---@field isAdmin boolean
 	---@field isReady boolean
 	---@field isBot boolean 💾
-	---@field isZombie boolean 💾
+	---@field isZombie boolean 💾 Whether the bot player should always run towards it's target.
 	---@field human? Human 💾 The human they currently control.
 	---@field connection? Connection 🔒 Their network connection.
 	---@field account? Account Their account.
@@ -266,6 +266,13 @@ do
 	---@field leftLegHP integer
 	---@field rightLegHP integer
 	---@field progressBar integer Progress bar displayed in the center of the screen, 0-255. 0 = disabled.
+	---@field inventoryAnimationFlags integer 
+	---@field inventoryAnimationProgress integer 
+	---@field inventoryAnimationDuration number 
+	---@field inventoryAnimationHand integer 
+	---@field inventoryAnimationSlot integer 
+	---@field inventoryAnimationCounter integer 
+	---@field inventoryAnimationCounterFinished integer 
 	---@field gender integer See Player.gender.
 	---@field head integer See Player.head.
 	---@field skinColor integer See Player.skinColor.
@@ -404,6 +411,11 @@ do
 	---@field rigidBody RigidBody The rigid body representing the physics of this item.
 	---@field vehicle? Vehicle The vehicle which this item is a key for.
 	---@field grenadePrimer? Player The player who primed this grenade.
+	---@field phoneTexture integer 💾 The phone's texture ID. 0 for white, 1 for black.
+	---@field phoneNumber integer The number used to call this phone.
+	---@field displayPhoneNumber integer 💾 The number currently displayed on the phone.
+	---@field enteredPhoneNumber integer The number that has been entered on the phone. Will reset upon reaching 4 digits.
+	---@field connectedPhone? Item The phone that this phone is connected to.
 	local Item
 
 	---Remove self safely and fire a network event.
@@ -459,6 +471,10 @@ do
 	---@param columnIndex integer Which column to edit.
 	---@param color integer The color to set, between 0x00 and 0xFF.
 	function Item:computerSetColor(lineIndex, columnIndex, color) end
+	
+	---Increment the current line of a computer.
+	---Only works if this item is a computer.
+	function Item:computerIncrementLine() end
 end
 
 do


### PR DESCRIPTION
Descriptions might be inaccurate. `Human.inventoryAnimation` variables are missing descriptions.
Couldn't figure out what the "state" parameter of the quick line intersect functions is.